### PR TITLE
Release/1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
 		"not dead"
 	],
 	"engines": {
-		"node": "18.16.0",
-		"npm": "9.6.4"
+		"node": "^18.16.0",
+		"npm": "^9.5.1"
 	},
 	"main": "index.js",
 	"config": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tribe-embed",
-	"version": "1.0.2-rc1",
+	"version": "1.0.2",
 	"description": "Tribe Embed",
 	"author": "Modern Tribe <admin@tri.be>",
 	"license": "GPL-2.0-or-later",

--- a/src/Core.php
+++ b/src/Core.php
@@ -9,7 +9,7 @@ use WP_Block;
 
 final class Core {
 
-	public const VERSION     = '1.0.2-rc1';
+	public const VERSION     = '1.0.2';
 	public const PLUGIN_NAME = 'tribe-embed';
 
 	private static self $instance;

--- a/tribe-embed.php
+++ b/tribe-embed.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Tribe Embed
  * Plugin URI:        https://github.com/moderntribe/tribe-embed
  * Description:       A Tribe Embed Plugin.
- * Version:           1.0.2-rc1
+ * Version:           1.0.2
  * Requires at least: 6.3
  * Requires PHP:      8.0
  * Author:            Modern Tribe


### PR DESCRIPTION
Moar version version tweaks so GHAs node install doesn't complain. Bump version number for public release.

Resolves Issue https://github.com/moderntribe/tribe-embeds/issues/6