### PR TITLE
[MOOSE-182] Fix Fatal Errors

### DIFF
--- a/src/Providers/Dailymotion.php
+++ b/src/Providers/Dailymotion.php
@@ -36,8 +36,7 @@ final class Dailymotion extends Provider {
 		}
 
 		// get the URL from the transient.
-		// $image_data = get_transient( 'tribe-embed_' . $this->get_video_id() );
-		$image_data = false;
+		$image_data = get_transient( 'tribe-embed_' . $this->get_video_id() );
 
 		// if we don't have a transient.
 		if ( false === $image_data ) {
@@ -58,6 +57,10 @@ final class Dailymotion extends Provider {
 						$video_details
 					)
 				);
+
+				if ( $response_body === null ) {
+					return '';
+				}
 
 				// get the image url from the json.
 				$image_url = $response_body->$resolution;

--- a/src/Providers/Vimeo.php
+++ b/src/Providers/Vimeo.php
@@ -51,6 +51,10 @@ final class Vimeo extends Provider {
 				)
 			);
 
+			if ( $response_body === null ) {
+				return [];
+			}
+
 			foreach ( self::IMAGE_SIZES as $resolution ) {
 				// get the image url from the json.
 				$image_url = $response_body[0]->$resolution;


### PR DESCRIPTION
- fixes fatal error in Vimeo script where if no response body is available, the script doesn't know what to do
- implements the same fix in the Dailymotion script to prevent errors (we weren't getting any, just preventing anything else)
- allows Dailymotion script to use the transient it sets

Jira Ticket: https://moderntribe.atlassian.net/browse/MOOSE-185