### PR TITLE
Add ability to extend providers list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,3 +31,31 @@ If you need to rebuild the lando environment you will need to delete the `./dev/
 ### Building Plugin
 
 This repo is setup to use the [WP CLI dist-archive](https://developer.wordpress.org/cli/commands/dist-archive/) command.  To build the zip file for the make sure you have the dist-archive command package installed and run `wp dist-archive .` form the root folder. The zip file will be created one folder back form the root folder.
+
+
+### Providers
+
+Each provider represents separate service(YouTube, Vimeo, etc). In order to provide ability extend list of providers use `tribe-embeds_video_provider` hook. 
+For proper use add new class in your theme or plugin. Each provider should extend `Tribe\Tribe_Embed\Provider` class
+Usage example:
+```php
+class TestProvider extends \Tribe\Tribe_Embed\Provider {
+....
+}
+
+function is_allowed_provider(): bool {
+...
+}
+
+/**
+ * @var mixed|null $provider  
+ * @var array $video_url_data Video url parsed with parse_url
+ * @var array $block          The full block, including name and attributes.
+ */
+add_filter( 'tribe-embeds_video_provider', function( $provider, $video_url_data, $block ) {
+    if ( is_allowed_provider( $video_url_data['host'] ) ) {
+        return $provider;
+    }
+    return ( new TestProvider( $video_url_data ) );
+}, 10, 3 );
+```

--- a/readme.md
+++ b/readme.md
@@ -59,3 +59,12 @@ add_filter( 'tribe-embeds_video_provider', function( $provider, $video_url_data,
     return ( new TestProvider( $video_url_data ) );
 }, 10, 3 );
 ```
+A list of allowed providers can be updated via `tribe-embeds_allowed_provider_hosts` hook
+```php
+/**
+ * Allows to inject custom provider hosts
+ * @var array $allowed_hosts List of allowed hosts
+ * @var string $host         Current video hostname                          
+ */
+$allowed_hosts = apply_filters( 'tribe-embeds_allowed_provider_hosts', $allowed_hosts, $host );
+```

--- a/src/Core.php
+++ b/src/Core.php
@@ -348,6 +348,13 @@ final class Core {
 			$allowed_hosts = array_merge( YouTube::ALLOWED_HOSTS, Vimeo::ALLOWED_HOSTS, Dailymotion::ALLOWED_HOSTS );
 		}
 
+		/**
+		 * Allows to inject custom provider hosts
+		 * @var array $allowed_hosts List of allowed hosts
+		 * @var string $host         Current video hostname
+		 */
+		$allowed_hosts = apply_filters( 'tribe-embeds_allowed_provider_hosts', $allowed_hosts, $host );
+
 		if ( in_array( $host, $allowed_hosts ) ) {
 			return true;
 		}

--- a/src/Core.php
+++ b/src/Core.php
@@ -344,6 +344,7 @@ final class Core {
 	 * @param array  $allowed_hosts
 	 */
 	private function is_allowed_host( string $host, array $allowed_hosts = [] ): bool {
+		// Use default list of allowed hosts if nothing has been specified
 		if ( empty( $allowed_hosts ) ) {
 			$allowed_hosts = array_merge( YouTube::ALLOWED_HOSTS, Vimeo::ALLOWED_HOSTS, Dailymotion::ALLOWED_HOSTS );
 		}
@@ -359,6 +360,14 @@ final class Core {
 			return true;
 		}
 
+		/**
+		 * Check if requested host is in the list of allowed ones. This is a wildcard check with regex
+		 * and it is specifically handles problem with provider dynamic urls
+		 *
+		 * Example:
+		 * Wistia video embed: https://tri-4.wistia.com/medias/7c1s0ftfl3?embedType=web_component&seo=true&videoWidth=960
+		 * The `tri-4` part may vary and be different for different videos or/and accounts
+		 */
 		$allowed_hosts = array_filter( $allowed_hosts, static function ( $allowed ) use ( $host ) {
 			return (bool) preg_match( "/$allowed/i", $host );
 		} );


### PR DESCRIPTION
## What

Adds new hook `tribe-embeds_video_provider`
Hook allows to extend supported providers list without extra editing of the initial plugin